### PR TITLE
allow set account allocation on buy/sell orders

### DIFF
--- a/src/main/scala/com/larroy/ibclient/contract/FXContract.scala
+++ b/src/main/scala/com/larroy/ibclient/contract/FXContract.scala
@@ -1,0 +1,16 @@
+package com.larroy.ibclient.contract
+
+import com.ib.client.Contract
+import com.ib.client.Types.SecType
+
+// TODO: add more params
+
+/**
+ * @param symbol
+ */
+class FXContract(symbol: String) extends Contract {
+  symbol(symbol)
+  secType(SecType.CASH.name())
+  exchange("IDEALPRO")
+  currency("GBP")
+}

--- a/src/main/scala/com/larroy/ibclient/order/Buy.scala
+++ b/src/main/scala/com/larroy/ibclient/order/Buy.scala
@@ -7,4 +7,4 @@ import com.larroy.ibclient.order.kind.Kind
  * Buy Order
  * @author piotr 19.02.15
  */
-case class Buy(override val kind: Kind, override val quantity: Int) extends Order
+case class Buy(override val kind: Kind, override val quantity: Int, override val account: Option[String] = None) extends Order

--- a/src/main/scala/com/larroy/ibclient/order/Order.scala
+++ b/src/main/scala/com/larroy/ibclient/order/Order.scala
@@ -9,17 +9,24 @@ import com.larroy.ibclient.order.kind.Kind
 trait Order {
   def kind: Kind = ???
   def quantity: Int = ???
+  def account: Option[String] = ???
   def toIBOrder: IBOrder = {
     import com.larroy.ibclient.order.kind._
     val iBOrder = new IBOrder()
     this match {
-      case Buy(_, qty) ⇒ {
+      case Buy(_, qty, acct) ⇒ {
         iBOrder.action("BUY")
         iBOrder.totalQuantity(qty)
+        acct.collect {
+          case acctStr => iBOrder.account(acctStr)
+        }
       }
-      case Sell(_, qty) ⇒ {
+      case Sell(_, qty, acct) ⇒ {
         iBOrder.action("SELL")
         iBOrder.totalQuantity(qty)
+        acct.collect {
+          case acctStr => iBOrder.account(acctStr)
+        }
       }
     }
     this.kind match {

--- a/src/main/scala/com/larroy/ibclient/order/Sell.scala
+++ b/src/main/scala/com/larroy/ibclient/order/Sell.scala
@@ -6,4 +6,4 @@ import com.larroy.ibclient.order.kind.Kind
  * Sell order
  * @author piotr 19.02.15
  */
-case class Sell(override val kind: Kind, override val quantity: Int) extends Order
+case class Sell(override val kind: Kind, override val quantity: Int, override val account: Option[String] = None) extends Order

--- a/src/main/scala/com/larroy/ibclient/order/kind/Limit.scala
+++ b/src/main/scala/com/larroy/ibclient/order/kind/Limit.scala
@@ -2,5 +2,6 @@ package com.larroy.ibclient.order.kind
 
 /**
  * @author piotr 19.02.15
+ * @param limit price of max limit to buy
  */
 case class Limit(limit: Double) extends Kind


### PR DESCRIPTION
TWS was accepting the buy / sell order, but wasn't 'transmitting' the order until I set the account allocation manually in the TWS GUI. Now, if the account field is passed when creating a Buy / Sell, the 'account' field is set on the Java API for the order. More info here: https://interactivebrokers.github.io/tws-api/financial_advisor_methods_and_orders.html 